### PR TITLE
fix(iOS): add support for dynamic frameworks

### DIFF
--- a/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
+++ b/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
@@ -10,7 +10,12 @@
 #import "RCTConvert.h"
 #endif
 
+#if __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import "SEGAnalytics.h"
+#endif
+
 #import <Foundation/Foundation.h>
 
 @implementation SegmentAnalytics


### PR DESCRIPTION
If one uses CocoaPods and installs the 'Analytics' pod using the option for dynamic frameworks (use_frameworks!) The import of SEGAnalytics will no longer work. With this support we support dynamic frameworks, while being backwards compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/edtechfoundry/react-native-segment-analytics/3)
<!-- Reviewable:end -->
